### PR TITLE
for python: prevent deterministic start for each simulation (usually one...

### DIFF
--- a/python/algorithms/epsilon_greedy/annealing.py
+++ b/python/algorithms/epsilon_greedy/annealing.py
@@ -1,9 +1,6 @@
 import random
 import math
-
-def ind_max(x):
-  m = max(x)
-  return x.index(m)
+execfile("core.py")
 
 class AnnealingEpsilonGreedy():
   def __init__(self, counts, values):
@@ -19,16 +16,16 @@ class AnnealingEpsilonGreedy():
   def select_arm(self):
     t = sum(self.counts) + 1
     epsilon = 1 / math.log(t + 0.0000001)
-    
+
     if random.random() > epsilon:
       return ind_max(self.values)
     else:
       return random.randrange(len(self.values))
-  
+
   def update(self, chosen_arm, reward):
     self.counts[chosen_arm] = self.counts[chosen_arm] + 1
     n = self.counts[chosen_arm]
-    
+
     value = self.values[chosen_arm]
     new_value = ((n - 1) / float(n)) * value + (1 / float(n)) * reward
     self.values[chosen_arm] = new_value

--- a/python/algorithms/epsilon_greedy/standard.py
+++ b/python/algorithms/epsilon_greedy/standard.py
@@ -1,8 +1,5 @@
 import random
-
-def ind_max(x):
-  m = max(x)
-  return x.index(m)
+execfile("core.py")
 
 class EpsilonGreedy():
   def __init__(self, epsilon, counts, values):
@@ -21,11 +18,11 @@ class EpsilonGreedy():
       return ind_max(self.values)
     else:
       return random.randrange(len(self.values))
-  
+
   def update(self, chosen_arm, reward):
     self.counts[chosen_arm] = self.counts[chosen_arm] + 1
     n = self.counts[chosen_arm]
-    
+
     value = self.values[chosen_arm]
     new_value = ((n - 1) / float(n)) * value + (1 / float(n)) * reward
     self.values[chosen_arm] = new_value

--- a/python/algorithms/ucb/ucb1.py
+++ b/python/algorithms/ucb/ucb1.py
@@ -1,20 +1,17 @@
 import math
-
-def ind_max(x):
-  m = max(x)
-  return x.index(m)
+execfile("core.py")
 
 class UCB1():
   def __init__(self, counts, values):
     self.counts = counts
     self.values = values
     return
-  
+
   def initialize(self, n_arms):
     self.counts = [0 for col in range(n_arms)]
     self.values = [0.0 for col in range(n_arms)]
     return
-  
+
   def select_arm(self):
     n_arms = len(self.counts)
     for arm in range(n_arms):
@@ -27,7 +24,7 @@ class UCB1():
       bonus = math.sqrt((2 * math.log(total_counts)) / float(self.counts[arm]))
       ucb_values[arm] = self.values[arm] + bonus
     return ind_max(ucb_values)
-  
+
   def update(self, chosen_arm, reward):
     self.counts[chosen_arm] = self.counts[chosen_arm] + 1
     n = self.counts[chosen_arm]

--- a/python/algorithms/ucb/ucb2.py
+++ b/python/algorithms/ucb/ucb2.py
@@ -1,8 +1,5 @@
 import math
-
-def ind_max(x):
-  m = max(x)
-  return x.index(m)
+execfile("core.py")
 
 class UCB2(object):
   def __init__(self, alpha, counts, values):
@@ -16,22 +13,22 @@ class UCB2(object):
     self.__current_arm = 0
     self.__next_update = 0
     return
-  
+
   def initialize(self, n_arms):
     self.counts = [0 for col in range(n_arms)]
     self.values = [0.0 for col in range(n_arms)]
     self.r = [0 for col in range(n_arms)]
     self.__current_arm = 0
     self.__next_update = 0
-  
+
   def __bonus(self, n, r):
     tau = self.__tau(r)
     bonus = math.sqrt((1. + self.alpha) * math.log(math.e * float(n) / tau) / (2 * tau))
     return bonus
-  
+
   def __tau(self, r):
     return int(math.ceil((1 + self.alpha) ** r))
-  
+
   def __set_arm(self, arm):
     """
     When choosing a new arm, make sure we play that arm for
@@ -40,34 +37,34 @@ class UCB2(object):
     self.__current_arm = arm
     self.__next_update += max(1, self.__tau(self.r[arm] + 1) - self.__tau(self.r[arm]))
     self.r[arm] += 1
-  
+
   def select_arm(self):
     n_arms = len(self.counts)
-    
+
     # play each arm once
     for arm in range(n_arms):
       if self.counts[arm] == 0:
         self.__set_arm(arm)
         return arm
-    
+
     # make sure we aren't still playing the previous arm.
     if self.__next_update > sum(self.counts):
       return self.__current_arm
-    
+
     ucb_values = [0.0 for arm in range(n_arms)]
     total_counts = sum(self.counts)
     for arm in xrange(n_arms):
       bonus = self.__bonus(total_counts, self.r[arm])
       ucb_values[arm] = self.values[arm] + bonus
-    
+
     chosen_arm = ind_max(ucb_values)
     self.__set_arm(chosen_arm)
     return chosen_arm
-  
+
   def update(self, chosen_arm, reward):
     self.counts[chosen_arm] = self.counts[chosen_arm] + 1
     n = self.counts[chosen_arm]
-    
+
     value = self.values[chosen_arm]
     new_value = ((n - 1) / float(n)) * value + (1 / float(n)) * reward
     self.values[chosen_arm] = new_value

--- a/python/core.py
+++ b/python/core.py
@@ -1,6 +1,9 @@
 # Convenience functions
 def ind_max(x):
   m = max(x)
+  #in case of same values, decide randomly
+  if all(map(lambda k: k==m, x)):
+    return random.randrange(0,len(x))
   return x.index(m)
 
 # Need access to random numbers


### PR DESCRIPTION
Hey John,

really great book, thank you for that! Very great explanations and encouraged me a lot to play with the boundary conditions.

I spotted a little error when experimenting.

For 5 arms, the start percentage of chosing the right arm at the first draw should be 20% on average over the 5000 experiments that are the default, but it was around 2% for epsilon greedy  with epsilon=.1. That is equivalent to always choosing an inferior arm at the first draw for the 90% share of epsilon greedy. If the expected values from the arms are similar, this behaviour also influences the following steps for quite a number of draws.

The reason was the function ind_max which chooses the first index if all values are equal.

In python/algorithms/epsilon_greedy/test_standard.py, you permute the means list. That means it can also happen that the algorithm choses deterministicly the best arm if the best arm happens to be the first. 

After permuting the means, the arms' order is never touched again, so the behaviour of drawing the same arm (whichever one) persists over all similation, they all start with the same arm.

I could provide my plots if the explanation was poor,

Proposed solution: In case of same valued arms, choose randomly.

Lina
